### PR TITLE
Adds wasm32 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/shssoichiro/zxcvbn-rs"
 license = "MIT"
 name = "zxcvbn"
 repository = "https://github.com/shssoichiro/zxcvbn-rs"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2018"
 
 [badges]

--- a/src/matching/char_indexing.rs
+++ b/src/matching/char_indexing.rs
@@ -9,6 +9,12 @@ pub struct CharIndexableStr<'a> {
     indices: Vec<usize>,
 }
 
+impl CharIndexableStr<'_> {
+    pub(crate) fn char_count(&self) -> usize {
+        self.indices.len()
+    }
+}
+
 impl<'a> From<&'a str> for CharIndexableStr<'a> {
     fn from(s: &'a str) -> Self {
         CharIndexableStr {

--- a/src/matching/char_indexing.rs
+++ b/src/matching/char_indexing.rs
@@ -1,0 +1,29 @@
+use std::ops::Range;
+
+pub(crate) trait CharIndexable<'b> {
+    fn char_index(&'b self, range: Range<usize>) -> &'b str;
+}
+
+pub struct CharIndexableStr<'a> {
+    s: &'a str,
+    indices: Vec<usize>,
+}
+
+impl<'a> From<&'a str> for CharIndexableStr<'a> {
+    fn from(s: &'a str) -> Self {
+        CharIndexableStr {
+            indices: s.char_indices().map(|(i, _c)| i).collect(),
+            s,
+        }
+    }
+}
+
+impl<'a, 'b: 'a> CharIndexable<'b> for CharIndexableStr<'a> {
+    fn char_index(&'b self, range: Range<usize>) -> &'b str {
+        if range.end >= self.indices.len() {
+            &self.s[self.indices[range.start]..]
+        } else {
+            &self.s[self.indices[range.start]..self.indices[range.end]]
+        }
+    }
+}


### PR DESCRIPTION
We've added wasm32 support by eliminating the std::time::Instant usage and adding the `wasmbind` chrono feature since it was already a dependency.

Instead of using usize types in scoring which failed the overflow test on wasm32 we switched to consistently using u64 types. Wasm-bindgen allows for u64 types by translating to the BigInt type in JS.

All integration tests are passing when running `wasm-pack test --node` 